### PR TITLE
Move the project folder to the home directory and rename it

### DIFF
--- a/CompileLogWindow.cpp
+++ b/CompileLogWindow.cpp
@@ -106,7 +106,6 @@ void CompileLogWindow::MessageReceived (BMessage *message)
 			{
 				BString CompileLogFileName;
 				CompileLogFileName.SetTo(ProjectPath.String());
-				CompileLogFileName.Append("/projects/");
 				CompileLogFileName.Append(ProjectName.String());
 				CompileLogFileName.Append("/compile.log");
 				// one day ill replace this load code with bespecific stuff rather than

--- a/FileWindow.cpp
+++ b/FileWindow.cpp
@@ -498,11 +498,6 @@ void FileWindow::InitWindow(void)
 	{
 		GetCurrentPath();
 	}
-	
-	// change this for a better bstorage function
-	char cmd[256];
-	sprintf(cmd,"mkdir %s/projects",ProjectPath.String());
-	system(cmd);
 }
 // ---------------------------------------------------------------------------------------------------------- //
 
@@ -538,7 +533,7 @@ void FileWindow::CreateJamFile(void)
 	if (ProjectName.Length() !=0 && ProjectName.Compare("Untitled") != 0)
 	{
 		printf("CreateJam - %s\n\n",ProjectName.String());
-		sprintf(FileName,"%s/projects/%s/Jamfile",ProjectPath.String(),ProjectName.String());
+		sprintf(FileName,"%s/%s/Jamfile",ProjectPath.String(),ProjectName.String());
 		f = fopen(FileName,"w");
 		sprintf(tmp,"## BeOS Jamfile for %s ##\n",ProjectName.String());
 		x = fputs(tmp,f);
@@ -564,7 +559,7 @@ void FileWindow::CreateMakeFile(void)
 	if (ProjectName.Length() !=0 && ProjectName.Compare("Untitled") != 0)
 	{
 		printf("CreateMake - %s\n\n",ProjectName.String());
-		sprintf(FileName,"%s/projects/%s/makefile",ProjectPath.String(),ProjectName.String());
+		sprintf(FileName,"%s/%s/makefile",ProjectPath.String(),ProjectName.String());
 		f = fopen(FileName,"w");
 		sprintf(tmp,"## BeOS Makefile for %s ##\n",ProjectName.String());
 		x = fputs(tmp,f);
@@ -627,7 +622,7 @@ void FileWindow::CompileGCC(void)
 	{
 		// check to see if the makefile exists
 		char cmd[256];
-		sprintf(cmd,"%s/projects/%s/makefile",ProjectPath.String(),ProjectName.String());
+		sprintf(cmd,"%s/%s/makefile",ProjectPath.String(),ProjectName.String());
 		FILE *f;	
     	
     	printf("CompileGCC - cmd is %s\n",cmd); //debug
@@ -641,11 +636,11 @@ void FileWindow::CompileGCC(void)
 		int x;
 		char tmp[256];
 		char FileName[256];
-		sprintf(FileName,"%s/projects/%s/compile.sh",ProjectPath.String(),ProjectName.String());
+		sprintf(FileName,"%s/%s/compile.sh",ProjectPath.String(),ProjectName.String());
 		f = fopen(FileName,"w");
 		x = fputs("#!/bin/sh\n",f);
 		x = fputs("# Compile and Run\n",f);
-		sprintf(tmp,"cd %s/projects/%s \n",ProjectPath.String(),ProjectName.String());
+		sprintf(tmp,"cd %s/%s \n",ProjectPath.String(),ProjectName.String());
 		x = fputs(tmp,f);
 		x = fputs("make clean\n",f);
 		sprintf(tmp,"make > compile.log OBJ_DIR=objects\n",ProjectPath.String(),ProjectName.String());
@@ -673,13 +668,13 @@ void FileWindow::SaveProject(void)
 		char FileName[256];
 		int x;
 		
-		sprintf(FileName,"%s/projects/%s.bprj",ProjectPath.String(),ProjectName.String());
+		sprintf(FileName,"%s/%s.bprj",ProjectPath.String(),ProjectName.String());
 		f = fopen(FileName,"w");
 		sprintf(tmp,"## BRIE Project File for %s ##\n",ProjectName.String());
 		x = fputs(tmp,f);
 		sprintf(tmp,"ProjectName=%s\n",ProjectName.String());
 		x = fputs(tmp,f);
-		sprintf(tmp,"ProjectDir=%s/projects/%s\n",ProjectPath.String(),ProjectName.String());
+		sprintf(tmp,"ProjectDir=%s/%s\n",ProjectPath.String(),ProjectName.String());
 		x = fputs(tmp,f);
 		sprintf(tmp,"Author=%s\n",ProjectAuthor.String());
 		x = fputs(tmp,f);

--- a/brieconstants.h
+++ b/brieconstants.h
@@ -47,7 +47,7 @@ const char projversion[]="v0.41";
 const char projcreation[]="Created using BRIE (http://brie.sf.net/";
 
 extern BString  ProjectName;
-extern BString  ProjectPath; // this is the current directory where brie is minus the /projects/
+extern BString  ProjectPath; // this is the current directory where brie is
 extern BString  ProjectAuthor;
 extern BMessage ProjectFiles;
 
@@ -58,5 +58,8 @@ extern int PanelType;
 
 // uses with HelpTipWindow
 extern int  TipNumber;
+
+// folder names
+#define BRIE_PROJECT_FOLDER_NAME "Brie Projects"
 
 #endif


### PR DESCRIPTION
This should be a kind of hacky fix that moves the projects/ folder to the
user's home directory. This should stop Brie from crashing when packaged.

The folder is now named "Brie Projects"

If I find time I also want to find out why the buttons of BRIE are garbled up and fix that too.